### PR TITLE
alias email to _email instead of removing

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -13,8 +13,7 @@ var reject = require('reject');
  */
 
 exports.track = function(track){
-  var props = track.properties();
-  if (props.email) delete props.email;
+  var props = track.properties({ email: '_email' });
   return {
     app_id: this.settings.appId,
     identity: track.userId(),
@@ -32,8 +31,7 @@ exports.track = function(track){
  */
 
 exports.identify = function(identify){
-  var traits = identify.traits();
-  if (traits.email) delete traits.email;
+  var traits = identify.traits({ email: '_email' });
   return {
     app_id: this.settings.appId,
     identity: identify.userId(),

--- a/test/fixtures/identify.json
+++ b/test/fixtures/identify.json
@@ -19,6 +19,7 @@
     "identity": "user-id",
     "properties": {
       "property": "value",
+      "_email": "email@email.com",
       "id": "user-id"
     }
   }

--- a/test/fixtures/track.json
+++ b/test/fixtures/track.json
@@ -20,7 +20,8 @@
     "identity": "user-id",
     "event": "my-event",
     "properties": {
-      "pass": "pass"
+      "pass": "pass",
+      "_email": "jd@example.com"
     }
   }
 }


### PR DESCRIPTION
From my initial discussion with Ravi @ Heap, I was under the impression that `email` was not used for anything as long as we used `handle` instead. But as he mentioned in a follow up email:

> Would it be possible to instead just re-map it to some other key name? E.g. "Email Address" or something? Users may still want to see it show up in our dashboard.

This fixes that. 

Corresponding client-side fix here: https://github.com/segmentio/analytics.js-integrations/pull/545
