### PR TITLE
support nested objs, dates, arrays

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -3,6 +3,10 @@
 */
 
 var reject = require('reject');
+var flatten = require('flat');
+var traverse = require('isodate-traverse');
+var is = require('is');
+var extend = require('extend');
 
 /**
  * Map `track`.
@@ -13,13 +17,13 @@ var reject = require('reject');
  */
 
 exports.track = function(track){
-  var props = track.properties({ email: '_email' });
+  var props = clean(track.properties({ email: '_email' }));
   props.segment_library = track.proxy('context.library.name') || '';
   return {
     app_id: this.settings.appId,
     identity: track.userId(),
     event: track.event(),
-    properties: reject.types(props, ['array', 'object', 'date'])
+    properties: props
   };
 };
 
@@ -32,11 +36,57 @@ exports.track = function(track){
  */
 
 exports.identify = function(identify){
-  var traits = identify.traits({ email: '_email' });
+  var traits = clean(identify.traits({ email: '_email' }));
   traits.segment_library = identify.proxy('context.library.name') || '';
   return {
     app_id: this.settings.appId,
     identity: identify.userId(),
-    properties: reject.types(traits, ['array', 'object', 'date'])
+    properties: traits
   };
 };
+
+/**
+ * Clean all nested objects and arrays.
+ *
+ * @param {Object} obj
+ * @return {Object}
+ * @api public
+ */
+
+function clean(obj){
+  obj = traverse(obj);
+  var ret = {};
+
+  for (var k in obj) {
+    var value = obj[k];
+    if (null == value) continue;
+
+    // date
+    if (is.date(value)) {
+      ret[k] = value.toISOString();
+      continue;
+    }
+
+    // not object
+    if (value.toString() !== '[object Object]') {
+      ret[k] = value.toString();
+      continue;
+    }
+
+    // json
+    // must flatten including the name of the original trait/property
+    var nestedObj = {};
+    nestedObj[k] = value;
+    var flattenedObj = flatten(nestedObj, { safe: true });
+
+    // stringify arrays inside nested object to be consistent with top level behavior of arrays
+    for (var key in flattenedObj) {
+      if (is.array(flattenedObj[key])) flattenedObj[key] = JSON.stringify(flattenedObj[key]);
+    }
+
+    ret = extend(ret, flattenedObj);
+    delete ret[k];
+  }
+  return ret;
+}
+

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "test": "make test"
   },
   "dependencies": {
+    "extend": "^3.0.0",
+    "flat": "^2.0.0",
+    "is": "^3.1.0",
+    "isodate-traverse": "^0.3.2",
     "reject": "0.0.1",
     "segmentio-integration": "^3.2.0"
   },

--- a/test/fixtures/identify.json
+++ b/test/fixtures/identify.json
@@ -4,29 +4,38 @@
   },
   "input": {
     "type": "identify",
-    "userId": "user-id",
+    "userId": "123456",
     "traits": {
-      "email": "email@email.com",
-      "property": "value"
+      "email": "teemo@teemo.com",
+      "property": 3,
+      "foo": {
+        "bar": {
+          "hello": "teemo"
+        },
+        "cheese": ["1", 2, "cheers"],
+        "products": [
+          {"A": "Jello"},
+          {"B": "Peanut"}
+        ]
+      }
     },
     "context": {
       "library": {
         "name": "analytics-ios"
       }
-    },
-    "object": {
-      "reject":"this"
-    },
-    "array": ["things", "to", "reject"]
+    }
   },
   "output": {
     "app_id": "1535634150",
-    "identity": "user-id",
+    "identity": "123456",
     "properties": {
-      "property": "value",
-      "_email": "email@email.com",
-      "id": "user-id",
-      "segment_library": "analytics-ios"
+      "property": "3",
+      "_email": "teemo@teemo.com",
+      "id": "123456",
+      "segment_library": "analytics-ios",
+      "foo.bar.hello": "teemo",
+      "foo.cheese": "[\"1\",2,\"cheers\"]",
+      "foo.products": "[{\"A\":\"Jello\"},{\"B\":\"Peanut\"}]"
     }
   }
 }

--- a/test/fixtures/track.json
+++ b/test/fixtures/track.json
@@ -5,24 +5,38 @@
   "input": {
     "type": "track",
     "userId": "user-id",
-    "event": "my-event",
+    "event": "TEEEMO2",
+    "context": {
+      "library": {
+        "name": "analytics-node"
+      }
+    },
     "properties": {
-      "pass": "pass",
+      "pass": 1,
       "email": "jd@example.com",
-      "object": {
-        "reject":"this"
-      },
-      "array": ["things", "to", "reject"]
+      "foo": {
+        "bar": {
+          "hello": "teemo"
+        },
+        "cheese": ["1", 2, "cheers"],
+        "products": [
+          {"A": "Jello"},
+          {"B": "Peanut"}
+        ]
+      }
     }
   },
   "output": {
     "app_id": "1535634150",
     "identity": "user-id",
-    "event": "my-event",
+    "event": "TEEEMO2",
     "properties": {
-      "pass": "pass",
+      "pass": "1",
       "_email": "jd@example.com",
-      "segment_library": ""
+      "segment_library": "analytics-node",
+      "foo.bar.hello": "teemo",
+      "foo.cheese": "[\"1\",2,\"cheers\"]",
+      "foo.products": "[{\"A\":\"Jello\"},{\"B\":\"Peanut\"}]"
     }
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -69,6 +69,18 @@ describe('Heap', function () {
         .track(helpers.track())
         .error('cannot POST /api/track (400)', done);
     });
+
+    it('should convert dates into ISO string', function(done){
+      var json = test.fixture('track');
+      json.input.properties.date = new Date('2016');
+      json.output.properties.date = '2016-01-01T00:00:00.000Z';
+
+      test
+        .set(settings)
+        .track(json.input)
+        .sends(json.output)
+        .expects(200, done);
+    });
   });
 
   describe('.identify()', function () {
@@ -85,8 +97,20 @@ describe('Heap', function () {
     it('should error on invalid creds', function(done){
       test
         .set({ appId: 'x' })
-        .track(helpers.identify())
+        .identify(helpers.identify())
         .error('cannot POST /api/identify (400)', done);
+    });
+
+    it('should convert dates into ISO string', function(done){
+      var json = test.fixture('identify');
+      json.input.traits.datetime = new Date('2016');
+      json.output.properties.datetime = '2016-01-01T00:00:00.000Z';
+
+      test
+        .set(settings)
+        .identify(json.input)
+        .sends(json.output)
+        .expects(200, done);
     });
   });
 });


### PR DESCRIPTION
@f2prateek @radiofreejohn

Currently our Heap integration rejects all `arrays`, `objects`, or `date` types. We're going to be flattening these props/traits and stringifying everything.

John -- please take close look at the `fixtures/track.json` and `fixtures/identify.json` as the `input` would be a sample request we get and the `output` is the payload we would send the HEAP api. So far after QA, looks like everything is working alright.
