### PR TITLE
Update identify to use api/add_user_properties

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,7 +43,7 @@ Heap.prototype.track = function(payload, fn){
 
 Heap.prototype.identify = function(payload, fn){
   return this
-    .post('/identify')
+    .post('/add_user_properties')
     .type('json')
     .send(payload)
     .end(this.handle(fn));

--- a/test/index.js
+++ b/test/index.js
@@ -98,7 +98,7 @@ describe('Heap', function () {
       test
         .set({ appId: 'x' })
         .identify(helpers.identify())
-        .error('cannot POST /api/identify (400)', done);
+        .error('cannot POST /api/add_user_properties (400)', done);
     });
 
     it('should convert dates into ISO string', function(done){


### PR DESCRIPTION
Heap's Server-Side Identify has been renamed to Server-Side Add User Properties, and the endpoint url has been moved from `POST /api/identify` to `POST /api/add_user_properties`, as part of [the recent API update](https://heapanalytics.com/docs/updating-custom-api). Here are the latest docs for [Server-Side Add User Properties](https://heapanalytics.com/docs/server-side#add-user-properties). The old endpoint will be supported until June 1, 2016.
