### PR TITLE
reject events older than 15 min

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,15 @@ var Heap = module.exports = integration('Heap')
   .retries(2);
 
 /**
+ * Reject events older than 15 minutes
+ */ 
+
+Heap.ensure(function(msg){
+  var time = Date.now() - Date.parse(msg.timestamp());
+  if (time > 900000) return this.invalid('timestamp is older than 15 minutes');
+});
+
+/**
  * Track.
  *
  * @param {Track} track

--- a/test/index.js
+++ b/test/index.js
@@ -36,6 +36,12 @@ describe('Heap', function () {
     it('should be valid with appId', function () {
       test.valid({}, settings);
     });
+
+    it('should reject events older than 15 minutes', function() {
+      var tooOld = Date.now() - 900001;
+      var msg = { timestamp: new Date(tooOld) };
+      test.invalid(msg, settings);
+    });
   });
 
   describe('mapper', function(){


### PR DESCRIPTION
Fixes https://segment.atlassian.net/browse/INT-247

Heap requests that we reject events that are older than 15 minutes 

@segment-integrations/core 
